### PR TITLE
Remove import which was confusing IDEs

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,3 @@
-import proguard.gradle.ProGuardTask
-
 apply plugin: 'java'
 apply plugin: 'war'
 apply plugin: 'com.bmuschko.tomcat'
@@ -71,7 +69,7 @@ jacocoTestReport {
     }
 }
 
-task proguard(type: ProGuardTask, dependsOn: jar) {
+task proguard(type: proguard.gradle.ProGuardTask, dependsOn: jar) {
     configurations.runtime.each {
         println it
     }


### PR DESCRIPTION
Having the import for something where the dependency is declared further in the file was confusing some IDEs, so we can in-line the only reference to the imported class.