### PR TITLE
Remove Proguard

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -44,7 +44,6 @@ buildscript {
     }
 
     dependencies {
-        classpath 'net.sf.proguard:proguard-gradle:6.2.2'
         classpath 'com.bmuschko:gradle-tomcat-plugin:2.5'
         classpath 'org.junit.platform:junit-platform-gradle-plugin:1.2.0'
     }
@@ -67,80 +66,4 @@ jacocoTestReport {
         csv.enabled false
         html.destination file("${buildDir}/reports/coverage")
     }
-}
-
-task proguard(type: proguard.gradle.ProGuardTask, dependsOn: jar) {
-    configurations.runtime.each {
-        println it
-    }
-
-    injars jar.archivePath
-
-    outjars 'passwordsafe.jar'
-
-    libraryjars "${System.getProperty('java.home')}/lib/rt.jar"
-    libraryjars "${System.getProperty('java.home')}/lib/jce.jar"
-    libraryjars(configurations.runtime)
-
-    printmapping 'proguard.map'
-
-    dontusemixedcaseclassnames
-    dontshrink
-
-    keepclassmembers 'class * extends java.lang.Enum { \
-        public static **[] values(); \
-        public static ** valueOf(java.lang.String); \
-    }'
-
-    keepclassmembers 'class * implements java.io.Serializable { \
-        static final long serialVersionUID; \
-        static final java.io.ObjectStreamField[] serialPersistentFields; \
-        private void writeObject(java.io.ObjectOutputStream); \
-        private void readObject(java.io.ObjectInputStream); \
-        java.lang.Object writeReplace(); \
-        java.lang.Object readResolve(); \
-    }'
-
-    keep 'public class * implements javax.servlet.Filter'
-    keep 'public class * implements javax.servlet.Servlet'
-
-    keep 'public class com.enterprisepasswordsafe.engine.configuration.JDBCConfiguration'
-    keep 'public class * implements com.enterprisepasswordsafe.engine.dbabstraction.AbstractDAL'
-    keep 'public interface com.enterprisepasswordsafe.engine.integration.PasswordChanger'
-    keep 'public class com.enterprisepasswordsafe.engine.integration.PasswordChangerProperty'
-    keep 'public class * implements com.enterprisepasswordsafe.engine.integration.PasswordChanger { \
-        public void rollbackChange(java.sql.Connection, java.util.Map, java.util.Map, java.lang.String); \
-        public void changePassword(java.sql.Connection, java.util.Map, java.util.Map, java.lang.String); \
-        public java.util.List getProperties(); \
-        public void install(java.sql.Connection); \
-        public void uninstall(java.sql.Connection); \
-    }'
-    keepclassmembers 'public class * implements javax.security.auth.spi.LoginModule { \
-        void initialize(javax.security.auth.Subject, javax.security.auth.callback.CallbackHandler, java.util.Map<java.lang.String,?>, java.util.Map<java.lang.String,?>); \
-        boolean login(); \
-        boolean commit(); \
-        boolean abort(); \
-        boolean logout(); \
-    }'
-
-    keep 'public interface com.enterprisepasswordsafe.proguard.ExternalInterface'
-    keep 'public class * implements com.enterprisepasswordsafe.proguard.ExternalInterface { \
-        public *** *; \
-        public *** *(...); \
-    }'
-
-    keep 'public interface com.enterprisepasswordsafe.proguard.JavaBean'
-    keep 'public class * implements com.enterprisepasswordsafe.proguard.JavaBean { \
-        void set*(***); \
-        void set*(int, ***); \
-        boolean is*(); \
-        boolean is*(int); \
-        *** get*(); \
-        *** get*(int); \
-    }'
-
-    keepclassmembers 'public class com.enterprisepasswordsafe.engine.database.ConfigurationListenersDAO { \
-        void addListener( java.lang.String, com.enterprisepasswordsafe.engine.database.ConfigurationListenersDAO$ConfigurationListener ); \
-    }'
-
 }

--- a/src/main/java/com/enterprisepasswordsafe/engine/AccessControlDecryptor.java
+++ b/src/main/java/com/enterprisepasswordsafe/engine/AccessControlDecryptor.java
@@ -16,18 +16,14 @@
 
 package com.enterprisepasswordsafe.engine;
 
-import java.io.UnsupportedEncodingException;
-import java.security.GeneralSecurityException;
-
 import com.enterprisepasswordsafe.engine.database.Decrypter;
 import com.enterprisepasswordsafe.engine.database.Encrypter;
-import com.enterprisepasswordsafe.proguard.ExternalInterface;
 
 /**
  * Interface implemented by any object capable of decrypting an access control.
  */
 
-public interface AccessControlDecryptor extends ExternalInterface {
+public interface AccessControlDecryptor {
 
     /**
      * Gets the key decrypter method for use with the keystore

--- a/src/main/java/com/enterprisepasswordsafe/engine/configuration/EnvironmentVariableBackedJDBCConfigurationRepository.java
+++ b/src/main/java/com/enterprisepasswordsafe/engine/configuration/EnvironmentVariableBackedJDBCConfigurationRepository.java
@@ -16,17 +16,10 @@
 
 package com.enterprisepasswordsafe.engine.configuration;
 
-import com.enterprisepasswordsafe.engine.dbabstraction.SupportedDatabase;
-import com.enterprisepasswordsafe.engine.preferences.PreferencesRepository;
-import com.enterprisepasswordsafe.engine.preferences.UserPreferencesRepository;
-import com.enterprisepasswordsafe.proguard.ExternalInterface;
-
 import java.security.GeneralSecurityException;
-import java.util.ArrayList;
-import java.util.List;
 
 public class EnvironmentVariableBackedJDBCConfigurationRepository
-        implements JDBCConfigurationRepository, ExternalInterface {
+        implements JDBCConfigurationRepository {
 
 	private JDBCConnectionInformation connectionInformation;
 

--- a/src/main/java/com/enterprisepasswordsafe/engine/database/AccessControlDAO.java
+++ b/src/main/java/com/enterprisepasswordsafe/engine/database/AccessControlDAO.java
@@ -18,14 +18,12 @@ package com.enterprisepasswordsafe.engine.database;
 
 import com.enterprisepasswordsafe.engine.accesscontrol.AccessControl;
 import com.enterprisepasswordsafe.engine.users.UserClassifier;
-import com.enterprisepasswordsafe.proguard.ExternalInterface;
 
 import java.io.UnsupportedEncodingException;
 import java.security.GeneralSecurityException;
 import java.sql.SQLException;
 
-public abstract class AccessControlDAO
-	implements ExternalInterface {
+public abstract class AccessControlDAO {
 
     private UserClassifier userClassifier = new UserClassifier();
 

--- a/src/main/java/com/enterprisepasswordsafe/engine/database/AccessControledObject.java
+++ b/src/main/java/com/enterprisepasswordsafe/engine/database/AccessControledObject.java
@@ -16,15 +16,13 @@
 
 package com.enterprisepasswordsafe.engine.database;
 
-import com.enterprisepasswordsafe.proguard.JavaBean;
-
 import java.security.PrivateKey;
 import java.security.PublicKey;
 
 /**
  * Interface implemented by all objects which are subject to access control.
  */
-public interface AccessControledObject extends JavaBean {
+public interface AccessControledObject {
 	
 	/**
 	 * Return the ID of the object

--- a/src/main/java/com/enterprisepasswordsafe/engine/database/AccessRole.java
+++ b/src/main/java/com/enterprisepasswordsafe/engine/database/AccessRole.java
@@ -16,9 +16,6 @@
 
 package com.enterprisepasswordsafe.engine.database;
 
-import com.enterprisepasswordsafe.proguard.ExternalInterface;
-import com.enterprisepasswordsafe.proguard.JavaBean;
-
 import java.sql.ResultSet;
 import java.sql.SQLException;
 
@@ -26,7 +23,7 @@ import java.sql.SQLException;
  * Base class for all access roles for restricted access items.
  */
 
-public abstract class AccessRole implements ExternalInterface {
+public abstract class AccessRole {
 	/**
 	 * The requestor-only role
 	 */
@@ -156,7 +153,7 @@ public abstract class AccessRole implements ExternalInterface {
 	 */
 
 	public static class ApproverSummary
-		implements Comparable<ApproverSummary>, JavaBean {
+		implements Comparable<ApproverSummary> {
 		/**
 		 * The ID of the approver.
 		 */

--- a/src/main/java/com/enterprisepasswordsafe/engine/database/AccessRoleDAO.java
+++ b/src/main/java/com/enterprisepasswordsafe/engine/database/AccessRoleDAO.java
@@ -23,13 +23,11 @@ import java.util.HashSet;
 import java.util.Set;
 
 import com.enterprisepasswordsafe.engine.database.AccessRole.ApproverSummary;
-import com.enterprisepasswordsafe.proguard.ExternalInterface;
 
 /**
  * Data access object for the user objects.
  */
-public final class AccessRoleDAO
-	implements ExternalInterface {
+public final class AccessRoleDAO {
 
 	/**
 	 * The SQL to get an access role for a particular actor

--- a/src/main/java/com/enterprisepasswordsafe/engine/database/AccessSummary.java
+++ b/src/main/java/com/enterprisepasswordsafe/engine/database/AccessSummary.java
@@ -16,13 +16,11 @@
 
 package com.enterprisepasswordsafe.engine.database;
 
-import com.enterprisepasswordsafe.proguard.JavaBean;
-
 /**
  * Summary of a group holding only it's group name and id.
  */
 public class AccessSummary
-	implements Comparable<AccessSummary>, JavaBean {
+	implements Comparable<AccessSummary> {
 	
 	/**
 	 * The actor id.

--- a/src/main/java/com/enterprisepasswordsafe/engine/database/ApproverList.java
+++ b/src/main/java/com/enterprisepasswordsafe/engine/database/ApproverList.java
@@ -16,13 +16,10 @@
 
 package com.enterprisepasswordsafe.engine.database;
 
-import com.enterprisepasswordsafe.proguard.ExternalInterface;
-
 /**
  * Class holding the list of approvers for a particular item.
  */
-public class ApproverList
-    implements ExternalInterface {
+public class ApproverList {
 
 	/**
 	 * The state marker for a user who has approved a request.

--- a/src/main/java/com/enterprisepasswordsafe/engine/database/ApproverListDAO.java
+++ b/src/main/java/com/enterprisepasswordsafe/engine/database/ApproverListDAO.java
@@ -25,13 +25,12 @@ import java.util.Set;
 
 import com.enterprisepasswordsafe.engine.utils.DateFormatter;
 import com.enterprisepasswordsafe.engine.utils.IDGenerator;
-import com.enterprisepasswordsafe.proguard.ExternalInterface;
 
 /**
  * Data access object for the user objects.
  */
 
-public final class ApproverListDAO implements ExternalInterface {
+public final class ApproverListDAO {
 
 	/**
 	 * SQL to count the number of approvers in this list.

--- a/src/main/java/com/enterprisepasswordsafe/engine/database/AuthenticationSource.java
+++ b/src/main/java/com/enterprisepasswordsafe/engine/database/AuthenticationSource.java
@@ -29,15 +29,13 @@ import com.enterprisepasswordsafe.engine.jaas.JndiLoginModuleDummy;
 import com.enterprisepasswordsafe.engine.jaas.LDAPLoginModule;
 import com.enterprisepasswordsafe.engine.jaas.LDAPSearchAndBindLoginModule;
 import com.enterprisepasswordsafe.engine.utils.IDGenerator;
-import com.enterprisepasswordsafe.proguard.ExternalInterface;
-
 
 /**
  * Class representing an authentication source.
  */
 
 public final class AuthenticationSource
-        implements Comparable<AuthenticationSource>, ExternalInterface {
+        implements Comparable<AuthenticationSource> {
 
     /**
      * The name parameter.

--- a/src/main/java/com/enterprisepasswordsafe/engine/database/AuthenticationSourceDAO.java
+++ b/src/main/java/com/enterprisepasswordsafe/engine/database/AuthenticationSourceDAO.java
@@ -27,16 +27,11 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import com.enterprisepasswordsafe.proguard.ExternalInterface;
-
 /**
  * Data access object for the user access control.
- *
- * @author Compaq_Owner
  */
 
-public class AuthenticationSourceDAO
-	implements ExternalInterface {
+public class AuthenticationSourceDAO {
 
     /**
      * The SQL to get all the properties associated with a authorisation source.

--- a/src/main/java/com/enterprisepasswordsafe/engine/database/BOMFactory.java
+++ b/src/main/java/com/enterprisepasswordsafe/engine/database/BOMFactory.java
@@ -19,20 +19,16 @@ package com.enterprisepasswordsafe.engine.database;
 import java.security.GeneralSecurityException;
 import java.sql.Connection;
 import java.sql.SQLException;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 
 import com.enterprisepasswordsafe.engine.Repositories;
 import com.enterprisepasswordsafe.engine.configuration.JDBCConnectionInformation;
 import com.enterprisepasswordsafe.engine.dbabstraction.DALInterface;
-import com.enterprisepasswordsafe.proguard.ExternalInterface;
 
 /**
  * Factory for handling and releasing business object managers.
  */
 
-public final class BOMFactory
-    implements ExternalInterface {
+public final class BOMFactory {
 
 	//---------------------------------------
 

--- a/src/main/java/com/enterprisepasswordsafe/engine/database/Configuration.java
+++ b/src/main/java/com/enterprisepasswordsafe/engine/database/Configuration.java
@@ -16,8 +16,6 @@
 
 package com.enterprisepasswordsafe.engine.database;
 
-import com.enterprisepasswordsafe.proguard.ExternalInterface;
-
 /**
  * Object responsible for handling user configuration options.
  */

--- a/src/main/java/com/enterprisepasswordsafe/engine/database/ConfigurationDAO.java
+++ b/src/main/java/com/enterprisepasswordsafe/engine/database/ConfigurationDAO.java
@@ -23,11 +23,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import com.enterprisepasswordsafe.proguard.ExternalInterface;
-
 public final class ConfigurationDAO
-        extends JDBCBase
-        implements ExternalInterface {
+        extends JDBCBase {
 
     private static final String GET_SQL =
             "SELECT property_value FROM configuration WHERE property_name = ?";

--- a/src/main/java/com/enterprisepasswordsafe/engine/database/ConfigurationListenersDAO.java
+++ b/src/main/java/com/enterprisepasswordsafe/engine/database/ConfigurationListenersDAO.java
@@ -16,14 +16,12 @@
 
 package com.enterprisepasswordsafe.engine.database;
 
-import com.enterprisepasswordsafe.proguard.ExternalInterface;
-
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-public final class ConfigurationListenersDAO implements ExternalInterface {
+public final class ConfigurationListenersDAO {
 
     private static final Map<String, List<ConfigurationListener>> listeners = new HashMap<>();
 
@@ -48,8 +46,8 @@ public final class ConfigurationListenersDAO implements ExternalInterface {
     	}
     }
     
-    public interface ConfigurationListener extends ExternalInterface {
-    	public void configurationChange( String propertyName, String propertyValue );
+    public interface ConfigurationListener {
+    	void configurationChange(String propertyName, String propertyValue);
     }
 	
 }

--- a/src/main/java/com/enterprisepasswordsafe/engine/database/ConfigurationOption.java
+++ b/src/main/java/com/enterprisepasswordsafe/engine/database/ConfigurationOption.java
@@ -17,9 +17,8 @@
 package com.enterprisepasswordsafe.engine.database;
 
 import com.enterprisepasswordsafe.engine.passwords.AuditingLevel;
-import com.enterprisepasswordsafe.proguard.ExternalInterface;
 
-public enum ConfigurationOption implements ExternalInterface {
+public enum ConfigurationOption {
 
     ALLOW_BACK_BUTTON_TO_ACCESS_PASSWORD("password.back_to_password_allowed", "false"),
     DAYS_BEFORE_EXPIRY_TO_WARN("EPASSWARN", null),

--- a/src/main/java/com/enterprisepasswordsafe/engine/database/Encrypter.java
+++ b/src/main/java/com/enterprisepasswordsafe/engine/database/Encrypter.java
@@ -16,14 +16,12 @@
 
 package com.enterprisepasswordsafe.engine.database;
 
-import com.enterprisepasswordsafe.proguard.ExternalInterface;
-
 import java.security.GeneralSecurityException;
 
 /**
  * Interface for classes which can decrypt access keys.
  */
-public interface Encrypter extends ExternalInterface {
+public interface Encrypter {
 
 	/**
 	 * Encrypt a byte array and return a byte array which is the encrypted data.
@@ -32,5 +30,5 @@ public interface Encrypter extends ExternalInterface {
 	 * 
 	 * @return The encrypted data.
 	 */
-	public byte[] encrypt(byte[] data) throws GeneralSecurityException;
+	byte[] encrypt(byte[] data) throws GeneralSecurityException;
 }

--- a/src/main/java/com/enterprisepasswordsafe/engine/database/ExpandedTamperproofEventLogEntry.java
+++ b/src/main/java/com/enterprisepasswordsafe/engine/database/ExpandedTamperproofEventLogEntry.java
@@ -27,7 +27,6 @@ import com.enterprisepasswordsafe.engine.logging.LogEventHasher;
 import com.enterprisepasswordsafe.engine.logging.LogEventParser;
 import com.enterprisepasswordsafe.engine.users.UserClassifier;
 import com.enterprisepasswordsafe.engine.utils.PasswordUtils;
-import com.enterprisepasswordsafe.proguard.JavaBean;
 
 import java.io.UnsupportedEncodingException;
 import java.security.GeneralSecurityException;
@@ -43,7 +42,7 @@ import java.util.logging.Logger;
  * Object representing an entry in the event log.
  */
 public final class ExpandedTamperproofEventLogEntry
-		implements Comparable<ExpandedTamperproofEventLogEntry>, JavaBean {
+		implements Comparable<ExpandedTamperproofEventLogEntry> {
 
 	private static final String LOG_TAG = "DB::ETEF";
 

--- a/src/main/java/com/enterprisepasswordsafe/engine/database/Group.java
+++ b/src/main/java/com/enterprisepasswordsafe/engine/database/Group.java
@@ -30,14 +30,12 @@ import javax.crypto.SecretKey;
 
 import com.enterprisepasswordsafe.engine.GroupAccessControlDecryptor;
 import com.enterprisepasswordsafe.engine.utils.IDGenerator;
-import com.enterprisepasswordsafe.proguard.ExternalInterface;
-
 
 /**
  * Object representation of a group within the system.
  */
 public final class Group
-    implements Comparable<Group>, EntityWithAccessRights, GroupAccessControlDecryptor, ExternalInterface {
+    implements Comparable<Group>, EntityWithAccessRights, GroupAccessControlDecryptor {
 
 	/**
 	 * The group statuses

--- a/src/main/java/com/enterprisepasswordsafe/engine/database/GroupAccessControlDAO.java
+++ b/src/main/java/com/enterprisepasswordsafe/engine/database/GroupAccessControlDAO.java
@@ -21,7 +21,6 @@ import com.enterprisepasswordsafe.engine.accesscontrol.GroupAccessControl;
 import com.enterprisepasswordsafe.engine.accesscontrol.PasswordPermission;
 import com.enterprisepasswordsafe.engine.database.schema.AccessControlDAOInterface;
 import com.enterprisepasswordsafe.engine.utils.KeyUtils;
-import com.enterprisepasswordsafe.proguard.ExternalInterface;
 
 import java.io.UnsupportedEncodingException;
 import java.security.GeneralSecurityException;
@@ -39,7 +38,7 @@ import java.util.TreeSet;
 
 public class GroupAccessControlDAO
     extends AbstractAccessControlDAO
-    implements AccessControlDAOInterface<Group, GroupAccessControl>, ExternalInterface {
+    implements AccessControlDAOInterface<Group, GroupAccessControl> {
 
     /**
      * The fields needed to construct a GroupAccessControl from a ResultSet.
@@ -347,7 +346,7 @@ public class GroupAccessControlDAO
     }
 
     public void update(final Group group, final GroupAccessControl gac)
-            throws SQLException, GeneralSecurityException, UnsupportedEncodingException {
+            throws SQLException, GeneralSecurityException {
 // TODO: Look at improving update
     	delete(gac);
     	write(group, gac);

--- a/src/main/java/com/enterprisepasswordsafe/engine/database/GroupAccessRoleDAO.java
+++ b/src/main/java/com/enterprisepasswordsafe/engine/database/GroupAccessRoleDAO.java
@@ -19,11 +19,8 @@ package com.enterprisepasswordsafe.engine.database;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
 
-import com.enterprisepasswordsafe.proguard.ExternalInterface;
-
 public final class GroupAccessRoleDAO
-		extends AbstractAccessRoleDAO<GroupAccessRole>
-		implements ExternalInterface {
+		extends AbstractAccessRoleDAO<GroupAccessRole> {
 
 	private static final String GET_ALL_SQL =
 			"SELECT actor_id, role FROM group_access_roles WHERE item_id = ? ";

--- a/src/main/java/com/enterprisepasswordsafe/engine/database/GroupDAO.java
+++ b/src/main/java/com/enterprisepasswordsafe/engine/database/GroupDAO.java
@@ -18,7 +18,6 @@ package com.enterprisepasswordsafe.engine.database;
 
 import com.enterprisepasswordsafe.engine.users.UserClassifier;
 import com.enterprisepasswordsafe.engine.utils.IDGenerator;
-import com.enterprisepasswordsafe.proguard.ExternalInterface;
 import org.apache.commons.csv.CSVRecord;
 
 import java.io.UnsupportedEncodingException;
@@ -30,7 +29,7 @@ import java.util.List;
 /**
  * Data access object for the group objects.
  */
-public class GroupDAO extends GroupStoreManipulator implements ExternalInterface {
+public class GroupDAO extends GroupStoreManipulator {
 
     /**
      * The clause for excluding reserved system groups

--- a/src/main/java/com/enterprisepasswordsafe/engine/database/HierarchyNode.java
+++ b/src/main/java/com/enterprisepasswordsafe/engine/database/HierarchyNode.java
@@ -20,13 +20,12 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 
 import com.enterprisepasswordsafe.engine.utils.IDGenerator;
-import com.enterprisepasswordsafe.proguard.ExternalInterface;
 
 /**
  * Representation of a node in the hierarchy.
  */
 public final class HierarchyNode
-	implements Cloneable, Comparable<HierarchyNode>, ExternalInterface {
+	implements Cloneable, Comparable<HierarchyNode> {
 	
     /**
      * The ID of the root node.
@@ -140,7 +139,7 @@ public final class HierarchyNode
     /**
      * Compare to another object.
      *
-     * @param otherObj
+     * @param otherNode
      *            The other object.
      *
      * @return The result of comparing the names of the nodes.

--- a/src/main/java/com/enterprisepasswordsafe/engine/database/HierarchyNodeAccessRule.java
+++ b/src/main/java/com/enterprisepasswordsafe/engine/database/HierarchyNodeAccessRule.java
@@ -16,14 +16,12 @@
 
 package com.enterprisepasswordsafe.engine.database;
 
-import com.enterprisepasswordsafe.proguard.JavaBean;
-
 /**
  * An access rul for a hierarchy node.
  */
 
 public class HierarchyNodeAccessRule
-	implements Comparable<HierarchyNodeAccessRule>, JavaBean {
+	implements Comparable<HierarchyNodeAccessRule> {
 	/**
 	 * The ID of the actor this rule is for.
 	 */
@@ -83,7 +81,7 @@ public class HierarchyNodeAccessRule
 	/**
 	 * Compare with another hierarchy node access rule.
 	 * 
-	 * @param o The other rule.
+	 * @param otherRule The other rule.
 	 */
 	public int compareTo(HierarchyNodeAccessRule otherRule) {
 		return actorName.compareToIgnoreCase(otherRule.actorName);

--- a/src/main/java/com/enterprisepasswordsafe/engine/database/HierarchyNodeAccessRuleDAO.java
+++ b/src/main/java/com/enterprisepasswordsafe/engine/database/HierarchyNodeAccessRuleDAO.java
@@ -24,13 +24,12 @@ import java.sql.SQLException;
 import java.util.*;
 
 import com.enterprisepasswordsafe.engine.database.derived.UserSummary;
-import com.enterprisepasswordsafe.proguard.ExternalInterface;
 
 /**
  * Data access object for hierarchy node access rules.
  */
 
-public abstract class HierarchyNodeAccessRuleDAO implements ExternalInterface {
+public abstract class HierarchyNodeAccessRuleDAO {
 
     /**
      * The values for an accessibility rule.

--- a/src/main/java/com/enterprisepasswordsafe/engine/database/HierarchyNodeDAO.java
+++ b/src/main/java/com/enterprisepasswordsafe/engine/database/HierarchyNodeDAO.java
@@ -27,19 +27,15 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import com.enterprisepasswordsafe.engine.accesscontrol.AccessControl;
-import com.enterprisepasswordsafe.engine.accesscontrol.GroupAccessControl;
-import com.enterprisepasswordsafe.engine.accesscontrol.UserAccessControl;
 import com.enterprisepasswordsafe.engine.database.derived.HierarchyNodeSummary;
 import com.enterprisepasswordsafe.engine.users.UserClassifier;
 import com.enterprisepasswordsafe.engine.utils.Cache;
-import com.enterprisepasswordsafe.proguard.ExternalInterface;
 
 /**
  * Data access object for nodes in the hierarchy.
  */
 public final class HierarchyNodeDAO
-    extends StoredObjectManipulator<HierarchyNode>
-    implements ExternalInterface {
+    extends StoredObjectManipulator<HierarchyNode> {
 
 	/**
      * The shared root node.

--- a/src/main/java/com/enterprisepasswordsafe/engine/database/HistoricalPassword.java
+++ b/src/main/java/com/enterprisepasswordsafe/engine/database/HistoricalPassword.java
@@ -24,7 +24,6 @@ package com.enterprisepasswordsafe.engine.database;
 
 import com.enterprisepasswordsafe.engine.accesscontrol.AccessControl;
 import com.enterprisepasswordsafe.engine.utils.PasswordUtils;
-import com.enterprisepasswordsafe.proguard.ExternalInterface;
 
 import java.io.IOException;
 import java.security.GeneralSecurityException;
@@ -33,8 +32,7 @@ import java.security.GeneralSecurityException;
  * Object representing a password from the past.
  */
 public final class HistoricalPassword
-        extends PasswordBase
-        implements ExternalInterface {
+        extends PasswordBase {
 
     private static final PasswordUtils<HistoricalPassword> passwordUtils = new PasswordUtils<>();
 

--- a/src/main/java/com/enterprisepasswordsafe/engine/database/HistoricalPasswordDAO.java
+++ b/src/main/java/com/enterprisepasswordsafe/engine/database/HistoricalPasswordDAO.java
@@ -17,7 +17,6 @@
 package com.enterprisepasswordsafe.engine.database;
 
 import java.io.IOException;
-import java.io.UnsupportedEncodingException;
 import java.security.GeneralSecurityException;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
@@ -26,9 +25,8 @@ import java.sql.SQLException;
 import com.enterprisepasswordsafe.engine.accesscontrol.AccessControl;
 import com.enterprisepasswordsafe.engine.utils.DateFormatter;
 import com.enterprisepasswordsafe.engine.utils.PasswordUtils;
-import com.enterprisepasswordsafe.proguard.ExternalInterface;
 
-public class HistoricalPasswordDAO implements ExternalInterface {
+public class HistoricalPasswordDAO {
 
     public static final String HISTORICAL_PASSWORD_FIELDS = PasswordBase.PASSWORD_BASE_FIELDS + ", pass.dt_l";
 

--- a/src/main/java/com/enterprisepasswordsafe/engine/database/IPZone.java
+++ b/src/main/java/com/enterprisepasswordsafe/engine/database/IPZone.java
@@ -24,12 +24,11 @@ import java.sql.SQLException;
 import java.util.StringTokenizer;
 
 import com.enterprisepasswordsafe.engine.utils.IDGenerator;
-import com.enterprisepasswordsafe.proguard.ExternalInterface;
 
 /**
  * Representation of an IP address range which rules can be set for.
  */
-public class IPZone implements ExternalInterface {
+public class IPZone {
     /**
      * The ID of this IP zone
      */

--- a/src/main/java/com/enterprisepasswordsafe/engine/database/IPZoneDAO.java
+++ b/src/main/java/com/enterprisepasswordsafe/engine/database/IPZoneDAO.java
@@ -16,16 +16,13 @@
 
 package com.enterprisepasswordsafe.engine.database;
 
-import com.enterprisepasswordsafe.proguard.ExternalInterface;
-
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.List;
 
 public class IPZoneDAO
-    extends StoredObjectFetcher<IPZone>
-	implements ExternalInterface {
+    extends StoredObjectFetcher<IPZone> {
 
     private static final String GET_ZONES =
         "SELECT ip_zone_id, name, ip_version, ip_start, ip_end FROM ip_zones ORDER BY name ";

--- a/src/main/java/com/enterprisepasswordsafe/engine/database/IntegrationModule.java
+++ b/src/main/java/com/enterprisepasswordsafe/engine/database/IntegrationModule.java
@@ -21,13 +21,12 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 
 import com.enterprisepasswordsafe.engine.utils.IDGenerator;
-import com.enterprisepasswordsafe.proguard.ExternalInterface;
 
 /**
  * Object handling the storage of the details of an integration module.
  */
 public final class IntegrationModule
-        implements Serializable, ExternalInterface {
+        implements Serializable {
 	
     /**
 	 * 

--- a/src/main/java/com/enterprisepasswordsafe/engine/database/IntegrationModuleConfigurationDAO.java
+++ b/src/main/java/com/enterprisepasswordsafe/engine/database/IntegrationModuleConfigurationDAO.java
@@ -22,11 +22,8 @@ import java.sql.SQLException;
 import java.util.HashMap;
 import java.util.Map;
 
-import com.enterprisepasswordsafe.proguard.ExternalInterface;
-
 public final class IntegrationModuleConfigurationDAO
-		extends JDBCBase
-		implements ExternalInterface {
+		extends JDBCBase {
 
 	private static final String ALL_PASSWORDS_MARKER = "*";
 

--- a/src/main/java/com/enterprisepasswordsafe/engine/database/IntegrationModuleDAO.java
+++ b/src/main/java/com/enterprisepasswordsafe/engine/database/IntegrationModuleDAO.java
@@ -16,20 +16,15 @@
 
 package com.enterprisepasswordsafe.engine.database;
 
-import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
-import java.sql.Statement;
-import java.util.ArrayList;
 import java.util.List;
 
 import com.enterprisepasswordsafe.engine.integration.PasswordChanger;
 import com.enterprisepasswordsafe.engine.integration.PasswordChangerProperty;
-import com.enterprisepasswordsafe.proguard.ExternalInterface;
 
 public final class IntegrationModuleDAO
-        extends StoredObjectFetcher<IntegrationModule>
-    	implements ExternalInterface {
+        extends StoredObjectFetcher<IntegrationModule> {
 
     private static final String GET_SQL = "SELECT module_id, name, className FROM intmodules WHERE module_id = ? ";
 

--- a/src/main/java/com/enterprisepasswordsafe/engine/database/IntegrationModuleScript.java
+++ b/src/main/java/com/enterprisepasswordsafe/engine/database/IntegrationModuleScript.java
@@ -22,12 +22,11 @@ import java.sql.SQLException;
 
 import com.enterprisepasswordsafe.engine.utils.Constants;
 import com.enterprisepasswordsafe.engine.utils.IDGenerator;
-import com.enterprisepasswordsafe.proguard.ExternalInterface;
 
 /**
  * Object handling the storage and manipulation of integration module scripts
  */
-public final class IntegrationModuleScript implements ExternalInterface{
+public final class IntegrationModuleScript {
     /**
      * The id of the script.
      */
@@ -135,8 +134,6 @@ public final class IntegrationModuleScript implements ExternalInterface{
     
     /**
      * Get the script.
-     * 
-     * @param conn The connection to the database.
      * 
      * @return The script.
      * @throws UnsupportedEncodingException 

--- a/src/main/java/com/enterprisepasswordsafe/engine/database/IntegrationModuleScriptDAO.java
+++ b/src/main/java/com/enterprisepasswordsafe/engine/database/IntegrationModuleScriptDAO.java
@@ -18,7 +18,6 @@ package com.enterprisepasswordsafe.engine.database;
 
 import com.enterprisepasswordsafe.engine.database.derived.IntegrationModuleScriptSummary;
 import com.enterprisepasswordsafe.engine.utils.Constants;
-import com.enterprisepasswordsafe.proguard.ExternalInterface;
 
 import java.io.UnsupportedEncodingException;
 import java.sql.PreparedStatement;
@@ -26,8 +25,7 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.*;
 
-
-public final class IntegrationModuleScriptDAO implements ExternalInterface {
+public final class IntegrationModuleScriptDAO {
 
     private static final String GET_SQL =
             "SELECT   script_id, module_id, name, script FROM intmodules_scripts WHERE script_id = ? ";

--- a/src/main/java/com/enterprisepasswordsafe/engine/database/LocationDAO.java
+++ b/src/main/java/com/enterprisepasswordsafe/engine/database/LocationDAO.java
@@ -17,7 +17,6 @@
 package com.enterprisepasswordsafe.engine.database;
 
 import com.enterprisepasswordsafe.engine.utils.IDGenerator;
-import com.enterprisepasswordsafe.proguard.ExternalInterface;
 
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
@@ -25,8 +24,7 @@ import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.List;
 
-public class LocationDAO
-	implements ExternalInterface {
+public class LocationDAO {
 
 	private static final String GET_BY_NAME_SQL = "select id from locations where name = ?";
 

--- a/src/main/java/com/enterprisepasswordsafe/engine/database/Membership.java
+++ b/src/main/java/com/enterprisepasswordsafe/engine/database/Membership.java
@@ -25,12 +25,11 @@ import javax.crypto.Cipher;
 import javax.crypto.SecretKey;
 
 import com.enterprisepasswordsafe.engine.utils.KeyUtils;
-import com.enterprisepasswordsafe.proguard.JavaBean;
 
 /**
  * Object representing the membership of a user in a group.
  */
-public class Membership implements JavaBean {
+public class Membership {
 
     /**
      * The ID of the user involved in the membership.

--- a/src/main/java/com/enterprisepasswordsafe/engine/database/MembershipDAO.java
+++ b/src/main/java/com/enterprisepasswordsafe/engine/database/MembershipDAO.java
@@ -18,7 +18,6 @@ package com.enterprisepasswordsafe.engine.database;
 
 import com.enterprisepasswordsafe.engine.utils.InvalidLicenceException;
 import com.enterprisepasswordsafe.engine.utils.KeyUtils;
-import com.enterprisepasswordsafe.proguard.ExternalInterface;
 
 import javax.crypto.SecretKey;
 import java.io.UnsupportedEncodingException;
@@ -33,8 +32,7 @@ import java.util.List;
 import java.util.Map;
 
 public final class MembershipDAO
-		extends JDBCBase
-		implements ExternalInterface {
+		extends JDBCBase {
 
     private static final Object MEMBERSHIP_MARKER = new Object();
 

--- a/src/main/java/com/enterprisepasswordsafe/engine/database/Password.java
+++ b/src/main/java/com/enterprisepasswordsafe/engine/database/Password.java
@@ -29,7 +29,6 @@ import java.util.Map;
 import com.enterprisepasswordsafe.engine.accesscontrol.AccessControl;
 import com.enterprisepasswordsafe.engine.passwords.AuditingLevel;
 import com.enterprisepasswordsafe.engine.passwords.PasswordPropertiesSerializer;
-import com.enterprisepasswordsafe.proguard.ExternalInterface;
 
 /**
  * Object representing a password.
@@ -37,7 +36,7 @@ import com.enterprisepasswordsafe.proguard.ExternalInterface;
 
 public final class Password
 	extends PasswordBase
-	implements Serializable, ExternalInterface {
+	implements Serializable {
 
     /**
      * The values for a password type.

--- a/src/main/java/com/enterprisepasswordsafe/engine/database/PasswordBase.java
+++ b/src/main/java/com/enterprisepasswordsafe/engine/database/PasswordBase.java
@@ -35,14 +35,12 @@ import com.enterprisepasswordsafe.engine.accesscontrol.AccessControl;
 import com.enterprisepasswordsafe.engine.utils.DateFormatter;
 import com.enterprisepasswordsafe.engine.utils.IDGenerator;
 import com.enterprisepasswordsafe.engine.utils.PasswordUtils;
-import com.enterprisepasswordsafe.proguard.ExternalInterface;
-
 
 /**
  * Base class for objects relating to passwords.
  */
 public abstract class PasswordBase
-	implements Comparable<PasswordBase>, AccessControledObject, ExternalInterface {
+	implements Comparable<PasswordBase>, AccessControledObject {
 
     /**
      * Number of millisecons in a day.

--- a/src/main/java/com/enterprisepasswordsafe/engine/database/PasswordDAO.java
+++ b/src/main/java/com/enterprisepasswordsafe/engine/database/PasswordDAO.java
@@ -26,7 +26,6 @@ import com.enterprisepasswordsafe.engine.passwords.AuditingLevel;
 import com.enterprisepasswordsafe.engine.passwords.PasswordPermissionApplier;
 import com.enterprisepasswordsafe.engine.utils.InvalidLicenceException;
 import com.enterprisepasswordsafe.engine.utils.PasswordUtils;
-import com.enterprisepasswordsafe.proguard.ExternalInterface;
 
 import java.io.IOException;
 import java.security.GeneralSecurityException;
@@ -36,8 +35,7 @@ import java.sql.SQLException;
 import java.util.*;
 
 public final class PasswordDAO
-        extends PasswordStoreManipulator
-        implements ExternalInterface {
+        extends PasswordStoreManipulator  {
 
     private static final int DEFAULT_PASSWORD_EXPIRY_WARNING_DAYS = 7;
 

--- a/src/main/java/com/enterprisepasswordsafe/engine/database/PasswordRestriction.java
+++ b/src/main/java/com/enterprisepasswordsafe/engine/database/PasswordRestriction.java
@@ -23,11 +23,9 @@ import java.util.ArrayList;
 import java.util.List;
 
 import com.enterprisepasswordsafe.engine.utils.IDGenerator;
-import com.enterprisepasswordsafe.proguard.ExternalInterface;
-import com.enterprisepasswordsafe.proguard.JavaBean;
 
 public class PasswordRestriction
-        implements Serializable, ExternalInterface {
+        implements Serializable {
 
     private static final String NO_LIMITS_STRING = "There are no restrictions on the contents of the password.";
 
@@ -282,7 +280,7 @@ public class PasswordRestriction
         return count == 1 ? "character" : "characters";
     }
 
-    public static class Summary implements JavaBean {
+    public static class Summary {
 
         public final String id;
 

--- a/src/main/java/com/enterprisepasswordsafe/engine/database/PasswordRestrictionDAO.java
+++ b/src/main/java/com/enterprisepasswordsafe/engine/database/PasswordRestrictionDAO.java
@@ -16,8 +16,6 @@
 
 package com.enterprisepasswordsafe.engine.database;
 
-import com.enterprisepasswordsafe.proguard.ExternalInterface;
-
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
@@ -25,8 +23,7 @@ import java.sql.Statement;
 import java.util.ArrayList;
 import java.util.List;
 
-public class PasswordRestrictionDAO
-	implements ExternalInterface {
+public class PasswordRestrictionDAO {
 
     private static final String GET_SQL =
             "SELECT restriction_id, name, min_numeric, min_lower, min_upper, " +

--- a/src/main/java/com/enterprisepasswordsafe/engine/database/RestrictedAccessRequest.java
+++ b/src/main/java/com/enterprisepasswordsafe/engine/database/RestrictedAccessRequest.java
@@ -21,9 +21,8 @@ import java.sql.SQLException;
 
 import com.enterprisepasswordsafe.engine.utils.DateFormatter;
 import com.enterprisepasswordsafe.engine.utils.IDGenerator;
-import com.enterprisepasswordsafe.proguard.ExternalInterface;
 
-public final class RestrictedAccessRequest implements ExternalInterface {
+public final class RestrictedAccessRequest {
 
 	/**
 	 * The ID of this request.

--- a/src/main/java/com/enterprisepasswordsafe/engine/database/RestrictedAccessRequestDAO.java
+++ b/src/main/java/com/enterprisepasswordsafe/engine/database/RestrictedAccessRequestDAO.java
@@ -18,7 +18,6 @@ package com.enterprisepasswordsafe.engine.database;
 
 import com.enterprisepasswordsafe.engine.database.AccessRole.ApproverSummary;
 import com.enterprisepasswordsafe.engine.utils.DateFormatter;
-import com.enterprisepasswordsafe.proguard.ExternalInterface;
 
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
@@ -27,7 +26,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 
-public final class RestrictedAccessRequestDAO implements ExternalInterface {
+public final class RestrictedAccessRequestDAO {
 
 	private static final String SQL_FIELDS =
 		"request_id, item_id, requester_id, approvers_list_id, request_dt_l, viewed_dt_l, reason";

--- a/src/main/java/com/enterprisepasswordsafe/engine/database/TamperproofEventLog.java
+++ b/src/main/java/com/enterprisepasswordsafe/engine/database/TamperproofEventLog.java
@@ -22,9 +22,7 @@
 
 package com.enterprisepasswordsafe.engine.database;
 
-
 import com.enterprisepasswordsafe.engine.logging.LogEventHasher;
-import com.enterprisepasswordsafe.proguard.JavaBean;
 
 import java.io.UnsupportedEncodingException;
 import java.security.GeneralSecurityException;
@@ -35,8 +33,7 @@ import java.util.Calendar;
 /**
  * Object representing an entry in the event log.
  */
-public final class TamperproofEventLog
-    implements JavaBean {
+public final class TamperproofEventLog {
 
 	/**
 	 * Dummy userId - Used to indicate no user was involved.

--- a/src/main/java/com/enterprisepasswordsafe/engine/database/TamperproofEventLogDAO.java
+++ b/src/main/java/com/enterprisepasswordsafe/engine/database/TamperproofEventLogDAO.java
@@ -27,11 +27,8 @@ import com.enterprisepasswordsafe.engine.hierarchy.HierarchyTools;
 import com.enterprisepasswordsafe.engine.logging.LogEventHasher;
 import com.enterprisepasswordsafe.engine.logging.LogEventMailer;
 import com.enterprisepasswordsafe.engine.utils.DateFormatter;
-import com.enterprisepasswordsafe.proguard.ExternalInterface;
-import com.enterprisepasswordsafe.proguard.JavaBean;
 
-public class TamperproofEventLogDAO
-	implements ExternalInterface {
+public class TamperproofEventLogDAO {
 
     private static final String GET_BY_DATE_RANGE_SQL =
         	"SELECT evl.dt_l, evl.user_id, evl.item_id, evl.event, evl.stamp_b, usr.user_name, pass.password_data, pass.history_stored"
@@ -240,8 +237,7 @@ public class TamperproofEventLogDAO
         daysEvents.add( ExpandedTamperproofEventLogEntry.from( rs, fetchingUser, adminGroup, validateTamperstamp));
     }
 
-    public static class EventsForDay
-        implements JavaBean {
+    public static class EventsForDay {
     	private final String humanReadableDate;
     	private final List<ExpandedTamperproofEventLogEntry> events;
 

--- a/src/main/java/com/enterprisepasswordsafe/engine/database/UnfilteredGroupDAO.java
+++ b/src/main/java/com/enterprisepasswordsafe/engine/database/UnfilteredGroupDAO.java
@@ -1,8 +1,6 @@
 package com.enterprisepasswordsafe.engine.database;
 
-import com.enterprisepasswordsafe.proguard.ExternalInterface;
-
-public class UnfilteredGroupDAO extends GroupStoreManipulator implements ExternalInterface {
+public class UnfilteredGroupDAO extends GroupStoreManipulator {
 
     /**
      * The SQL to get a particular group by its' ID (includes disabled groups).

--- a/src/main/java/com/enterprisepasswordsafe/engine/database/User.java
+++ b/src/main/java/com/enterprisepasswordsafe/engine/database/User.java
@@ -16,34 +16,27 @@
 
 package com.enterprisepasswordsafe.engine.database;
 
-import java.io.UnsupportedEncodingException;
-import java.security.*;
-import java.sql.PreparedStatement;
-import java.sql.ResultSet;
-import java.sql.SQLException;
-import java.util.Arrays;
-import java.util.Calendar;
-
-import javax.crypto.Cipher;
-import javax.crypto.KeyGenerator;
-import javax.crypto.SecretKey;
-import javax.crypto.spec.SecretKeySpec;
-
 import com.enterprisepasswordsafe.engine.UserAccessControlDecryptor;
 import com.enterprisepasswordsafe.engine.users.PasswordHasher;
 import com.enterprisepasswordsafe.engine.users.UserAccessKeyEncryptionHandler;
 import com.enterprisepasswordsafe.engine.users.UserClassifier;
 import com.enterprisepasswordsafe.engine.users.UserPasswordEncryptionHandler;
 import com.enterprisepasswordsafe.engine.utils.IDGenerator;
-import com.enterprisepasswordsafe.engine.utils.KeyUtils;
-import com.enterprisepasswordsafe.proguard.ExternalInterface;
 
+import javax.crypto.KeyGenerator;
+import javax.crypto.SecretKey;
+import javax.crypto.spec.SecretKeySpec;
+import java.io.UnsupportedEncodingException;
+import java.security.GeneralSecurityException;
+import java.security.NoSuchAlgorithmException;
+import java.sql.ResultSet;
+import java.sql.SQLException;
 
 /**
  * Object representing a user in the system.
  */
 public final class User
-    implements Comparable<User>, EntityWithAccessRights, UserAccessControlDecryptor, ExternalInterface {
+    implements Comparable<User>, EntityWithAccessRights, UserAccessControlDecryptor {
 
     /**
      * The size of the group access key in bits.

--- a/src/main/java/com/enterprisepasswordsafe/engine/database/UserAccessControlDAO.java
+++ b/src/main/java/com/enterprisepasswordsafe/engine/database/UserAccessControlDAO.java
@@ -17,12 +17,10 @@
 package com.enterprisepasswordsafe.engine.database;
 
 import com.enterprisepasswordsafe.engine.AccessControlDecryptor;
-import com.enterprisepasswordsafe.engine.accesscontrol.GroupAccessControl;
 import com.enterprisepasswordsafe.engine.accesscontrol.PasswordPermission;
 import com.enterprisepasswordsafe.engine.accesscontrol.UserAccessControl;
 import com.enterprisepasswordsafe.engine.database.schema.AccessControlDAOInterface;
 import com.enterprisepasswordsafe.engine.utils.KeyUtils;
-import com.enterprisepasswordsafe.proguard.ExternalInterface;
 
 import javax.crypto.BadPaddingException;
 import java.io.UnsupportedEncodingException;
@@ -40,7 +38,7 @@ import java.util.logging.Logger;
 
 public final class UserAccessControlDAO
 		extends AbstractAccessControlDAO
-		implements ExternalInterface, AccessControlDAOInterface<User, UserAccessControl> {
+		implements AccessControlDAOInterface<User, UserAccessControl> {
 
     public static final String UAC_FIELDS = " uac.item_id, uac.mkey, uac.rkey, uac.user_id ";
 

--- a/src/main/java/com/enterprisepasswordsafe/engine/database/UserAccessRoleDAO.java
+++ b/src/main/java/com/enterprisepasswordsafe/engine/database/UserAccessRoleDAO.java
@@ -16,14 +16,11 @@
 
 package com.enterprisepasswordsafe.engine.database;
 
-import com.enterprisepasswordsafe.proguard.ExternalInterface;
-
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
 
 public class UserAccessRoleDAO
-		extends AbstractAccessRoleDAO<UserAccessRole>
-		implements ExternalInterface {
+		extends AbstractAccessRoleDAO<UserAccessRole> {
 
 	private static final String GET_ALL_SQL =
 			"SELECT actor_id, role FROM user_access_roles WHERE item_id = ? ";

--- a/src/main/java/com/enterprisepasswordsafe/engine/database/UserDAO.java
+++ b/src/main/java/com/enterprisepasswordsafe/engine/database/UserDAO.java
@@ -16,19 +16,6 @@
 
 package com.enterprisepasswordsafe.engine.database;
 
-import java.io.UnsupportedEncodingException;
-import java.security.GeneralSecurityException;
-import java.sql.Connection;
-import java.sql.PreparedStatement;
-import java.sql.ResultSet;
-import java.sql.SQLException;
-import java.util.*;
-
-import javax.crypto.KeyGenerator;
-import javax.crypto.SecretKey;
-import javax.security.auth.login.LoginContext;
-import javax.security.auth.login.LoginException;
-
 import com.enterprisepasswordsafe.engine.database.derived.UserSummary;
 import com.enterprisepasswordsafe.engine.jaas.EPSJAASConfiguration;
 import com.enterprisepasswordsafe.engine.jaas.WebLoginCallbackHandler;
@@ -36,12 +23,24 @@ import com.enterprisepasswordsafe.engine.users.UserAccessKeyEncryptionHandler;
 import com.enterprisepasswordsafe.engine.users.UserClassifier;
 import com.enterprisepasswordsafe.engine.users.UserPasswordEncryptionHandler;
 import com.enterprisepasswordsafe.engine.utils.KeyUtils;
-import com.enterprisepasswordsafe.proguard.ExternalInterface;
+
+import javax.crypto.KeyGenerator;
+import javax.crypto.SecretKey;
+import javax.security.auth.login.LoginContext;
+import javax.security.auth.login.LoginException;
+import java.io.UnsupportedEncodingException;
+import java.security.GeneralSecurityException;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.Calendar;
+import java.util.List;
 
 /**
  * Data access object for the user objects.
  */
-public final class UserDAO extends StoredObjectManipulator<User> implements ExternalInterface {
+public final class UserDAO extends StoredObjectManipulator<User> {
 
     public static final String USER_FIELDS = "appusers.user_id, "
             + "appusers.user_name, appusers.user_pass_b, appusers.email, appusers.full_name, "

--- a/src/main/java/com/enterprisepasswordsafe/engine/database/UserIPZoneRestriction.java
+++ b/src/main/java/com/enterprisepasswordsafe/engine/database/UserIPZoneRestriction.java
@@ -16,15 +16,13 @@
 
 package com.enterprisepasswordsafe.engine.database;
 
-import com.enterprisepasswordsafe.proguard.ExternalInterface;
-
 import java.sql.ResultSet;
 import java.sql.SQLException;
 
 /**
  * Representation of a restriction for a user when they are trying to log in from a given zone.
  */
-public class UserIPZoneRestriction implements ExternalInterface {
+public class UserIPZoneRestriction {
 
     /**
      * The character to represent an "allow" rule. 

--- a/src/main/java/com/enterprisepasswordsafe/engine/database/UserIPZoneRestrictionDAO.java
+++ b/src/main/java/com/enterprisepasswordsafe/engine/database/UserIPZoneRestrictionDAO.java
@@ -16,8 +16,6 @@
 
 package com.enterprisepasswordsafe.engine.database;
 
-import com.enterprisepasswordsafe.proguard.ExternalInterface;
-
 import java.net.UnknownHostException;
 import java.security.GeneralSecurityException;
 import java.sql.PreparedStatement;
@@ -28,8 +26,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-public final class UserIPZoneRestrictionDAO
-    implements ExternalInterface {
+public final class UserIPZoneRestrictionDAO {
 
     private static final String GET_BY_USER_ID_AND_IP_SQL =
         "SELECT uipz.ip_zone_id, uipz.user_id, uipz.setting FROM user_ip_zones uipz,  ip_zones ipz "

--- a/src/main/java/com/enterprisepasswordsafe/engine/database/UserSummaryDAO.java
+++ b/src/main/java/com/enterprisepasswordsafe/engine/database/UserSummaryDAO.java
@@ -3,14 +3,13 @@ package com.enterprisepasswordsafe.engine.database;
 import com.enterprisepasswordsafe.engine.database.derived.UserSummary;
 import com.enterprisepasswordsafe.engine.users.UserClassifier;
 import com.enterprisepasswordsafe.engine.utils.Cache;
-import com.enterprisepasswordsafe.proguard.ExternalInterface;
 
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.List;
 
-public class UserSummaryDAO extends StoredObjectManipulator<UserSummary> implements ExternalInterface {
+public class UserSummaryDAO extends StoredObjectManipulator<UserSummary> {
 
     private static final String GET_SUMMARY_BY_ID =
             "SELECT   user_id, user_name, full_name "

--- a/src/main/java/com/enterprisepasswordsafe/engine/database/actions/NodeObjectAction.java
+++ b/src/main/java/com/enterprisepasswordsafe/engine/database/actions/NodeObjectAction.java
@@ -18,7 +18,6 @@ package com.enterprisepasswordsafe.engine.database.actions;
 
 import com.enterprisepasswordsafe.engine.database.AccessControledObject;
 import com.enterprisepasswordsafe.engine.database.HierarchyNode;
-import com.enterprisepasswordsafe.proguard.ExternalInterface;
 
 /**
  * Interface implemented by objects wishing to perform an action on a object in the hierarchy.
@@ -26,7 +25,7 @@ import com.enterprisepasswordsafe.proguard.ExternalInterface;
  * @author Al Sutton
  */
 
-public interface NodeObjectAction extends ExternalInterface {
+public interface NodeObjectAction {
     /**
      * Process a particular object.
      *

--- a/src/main/java/com/enterprisepasswordsafe/engine/database/actions/PasswordAction.java
+++ b/src/main/java/com/enterprisepasswordsafe/engine/database/actions/PasswordAction.java
@@ -18,7 +18,6 @@ package com.enterprisepasswordsafe.engine.database.actions;
 
 import com.enterprisepasswordsafe.engine.database.HierarchyNode;
 import com.enterprisepasswordsafe.engine.database.Password;
-import com.enterprisepasswordsafe.proguard.ExternalInterface;
 
 /**
  * Interface implemented by objects wishing to perform an action on a password.
@@ -26,7 +25,7 @@ import com.enterprisepasswordsafe.proguard.ExternalInterface;
  * @author Al Sutton
  */
 
-public interface PasswordAction extends ExternalInterface{
+public interface PasswordAction {
     /**
      * Process a particular password.
      *

--- a/src/main/java/com/enterprisepasswordsafe/engine/database/actions/search/SearchTest.java
+++ b/src/main/java/com/enterprisepasswordsafe/engine/database/actions/search/SearchTest.java
@@ -17,12 +17,11 @@
 package com.enterprisepasswordsafe.engine.database.actions.search;
 
 import com.enterprisepasswordsafe.engine.database.Password;
-import com.enterprisepasswordsafe.proguard.ExternalInterface;
 
 /**
  * Interface implemented by all classes which represent search test criteria.
  */
-public interface SearchTest extends ExternalInterface {
+public interface SearchTest {
     /**
      * Test to see if the password meets the criteria.
      *

--- a/src/main/java/com/enterprisepasswordsafe/engine/database/derived/ExpiringAccessiblePasswords.java
+++ b/src/main/java/com/enterprisepasswordsafe/engine/database/derived/ExpiringAccessiblePasswords.java
@@ -20,12 +20,11 @@ import java.util.HashSet;
 import java.util.Set;
 
 import com.enterprisepasswordsafe.engine.database.Password;
-import com.enterprisepasswordsafe.proguard.JavaBean;
 
 /**
  * Class holding the lists of expired and expiring passwords.
  */
-public class ExpiringAccessiblePasswords implements JavaBean {
+public class ExpiringAccessiblePasswords {
     /**
      * The list of expiring passwords (i.e. those in the warning period).
      */

--- a/src/main/java/com/enterprisepasswordsafe/engine/database/derived/HierarchyNodeChildren.java
+++ b/src/main/java/com/enterprisepasswordsafe/engine/database/derived/HierarchyNodeChildren.java
@@ -21,13 +21,11 @@ import java.util.Set;
 
 import com.enterprisepasswordsafe.engine.database.HierarchyNode;
 import com.enterprisepasswordsafe.engine.database.Password;
-import com.enterprisepasswordsafe.proguard.JavaBean;
 
 /**
  * Class holding the details of the children of a HierarchyNode
  */
-public class HierarchyNodeChildren
-    implements JavaBean {
+public class HierarchyNodeChildren {
 
     /**
      * The list of child container nodes.

--- a/src/main/java/com/enterprisepasswordsafe/engine/database/derived/HierarchyNodeSummary.java
+++ b/src/main/java/com/enterprisepasswordsafe/engine/database/derived/HierarchyNodeSummary.java
@@ -16,14 +16,12 @@
 
 package com.enterprisepasswordsafe.engine.database.derived;
 
-import com.enterprisepasswordsafe.proguard.JavaBean;
-
 /**
  * A class holding the summary of a node.
  */
 
 public class HierarchyNodeSummary
-	implements Comparable<HierarchyNodeSummary>, JavaBean {
+	implements Comparable<HierarchyNodeSummary> {
 
 	/**
 	 * The ID for the node.

--- a/src/main/java/com/enterprisepasswordsafe/engine/database/derived/PasswordSummary.java
+++ b/src/main/java/com/enterprisepasswordsafe/engine/database/derived/PasswordSummary.java
@@ -16,14 +16,12 @@
 
 package com.enterprisepasswordsafe.engine.database.derived;
 
-import com.enterprisepasswordsafe.proguard.JavaBean;
-
 /**
  * Summary for a password, saves memory over using a full Password object. 
  */
 
 public class PasswordSummary
-        implements Comparable<PasswordSummary>, JavaBean {
+        implements Comparable<PasswordSummary> {
 	/**
 	 * The ID of the password.
 	 */

--- a/src/main/java/com/enterprisepasswordsafe/engine/database/derived/UserSummary.java
+++ b/src/main/java/com/enterprisepasswordsafe/engine/database/derived/UserSummary.java
@@ -16,13 +16,11 @@
 
 package com.enterprisepasswordsafe.engine.database.derived;
 
-import com.enterprisepasswordsafe.proguard.JavaBean;
-
 /**
  * Summary information about a user, more memory efficient than a full User object.
  */
 public class UserSummary
-	implements Comparable<UserSummary>, JavaBean {
+	implements Comparable<UserSummary> {
 
     /**
      * The users id.

--- a/src/main/java/com/enterprisepasswordsafe/engine/database/exceptions/DatabaseUnavailableException.java
+++ b/src/main/java/com/enterprisepasswordsafe/engine/database/exceptions/DatabaseUnavailableException.java
@@ -16,13 +16,10 @@
 
 package com.enterprisepasswordsafe.engine.database.exceptions;
 
-import com.enterprisepasswordsafe.proguard.ExternalInterface;
-
 import java.sql.SQLException;
 
 public class DatabaseUnavailableException
-        extends SQLException
-        implements ExternalInterface {
+        extends SQLException {
 
     public DatabaseUnavailableException(final SQLException originalException) {
         super(originalException);

--- a/src/main/java/com/enterprisepasswordsafe/engine/dbabstraction/DALInterface.java
+++ b/src/main/java/com/enterprisepasswordsafe/engine/dbabstraction/DALInterface.java
@@ -16,8 +16,6 @@
 
 package com.enterprisepasswordsafe.engine.dbabstraction;
 
-import com.enterprisepasswordsafe.proguard.ExternalInterface;
-
 import java.sql.Connection;
 import java.sql.SQLException;
 
@@ -25,7 +23,7 @@ import java.sql.SQLException;
  * Interface implemented by all Database Abstraction Layer classes.
  */
 
-public interface DALInterface extends ExternalInterface
+public interface DALInterface
 {
 	/**
 	 * Add any parameters needed when creating a new database to

--- a/src/main/java/com/enterprisepasswordsafe/engine/dbpool/DatabasePool.java
+++ b/src/main/java/com/enterprisepasswordsafe/engine/dbpool/DatabasePool.java
@@ -16,6 +16,14 @@
 
 package com.enterprisepasswordsafe.engine.dbpool;
 
+import com.enterprisepasswordsafe.engine.configuration.JDBCConnectionInformation;
+import com.enterprisepasswordsafe.engine.database.schema.SchemaVersion;
+import com.enterprisepasswordsafe.engine.dbabstraction.DALFactory;
+import com.enterprisepasswordsafe.engine.dbabstraction.DALInterface;
+import org.apache.commons.dbcp2.*;
+import org.apache.commons.pool2.ObjectPool;
+import org.apache.commons.pool2.impl.GenericObjectPool;
+
 import java.io.UnsupportedEncodingException;
 import java.security.GeneralSecurityException;
 import java.sql.Connection;
@@ -25,16 +33,7 @@ import java.sql.SQLException;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-import com.enterprisepasswordsafe.engine.configuration.JDBCConnectionInformation;
-import com.enterprisepasswordsafe.engine.database.schema.SchemaVersion;
-import com.enterprisepasswordsafe.engine.dbabstraction.DALFactory;
-import com.enterprisepasswordsafe.engine.dbabstraction.DALInterface;
-import com.enterprisepasswordsafe.proguard.ExternalInterface;
-import org.apache.commons.dbcp2.*;
-import org.apache.commons.pool2.ObjectPool;
-import org.apache.commons.pool2.impl.GenericObjectPool;
-
-public final class DatabasePool implements ExternalInterface, AutoCloseable {
+public final class DatabasePool implements AutoCloseable {
 
     private static final Object VERIFICATION_LOCK = new Object();
 

--- a/src/main/java/com/enterprisepasswordsafe/engine/dbpool/DatabasePoolFactory.java
+++ b/src/main/java/com/enterprisepasswordsafe/engine/dbpool/DatabasePoolFactory.java
@@ -18,12 +18,11 @@ package com.enterprisepasswordsafe.engine.dbpool;
 
 import com.enterprisepasswordsafe.engine.Repositories;
 import com.enterprisepasswordsafe.engine.configuration.JDBCConnectionInformation;
-import com.enterprisepasswordsafe.proguard.ExternalInterface;
 
 import java.security.GeneralSecurityException;
 import java.sql.SQLException;
 
-public class DatabasePoolFactory implements ExternalInterface {
+public class DatabasePoolFactory {
 
     private static DatabasePool mSharedInstance;
 

--- a/src/main/java/com/enterprisepasswordsafe/engine/integration/PasswordChanger.java
+++ b/src/main/java/com/enterprisepasswordsafe/engine/integration/PasswordChanger.java
@@ -16,8 +16,6 @@
 
 package com.enterprisepasswordsafe.engine.integration;
 
-import com.enterprisepasswordsafe.proguard.ExternalInterface;
-
 import java.io.IOException;
 import java.rmi.RemoteException;
 import java.sql.Connection;
@@ -28,7 +26,7 @@ import java.util.Map;
  * The interface implemented by any class which can change the password
  * on a remote machine.
  */
-public interface PasswordChanger extends ExternalInterface {
+public interface PasswordChanger {
 	
 	/**
 	 * The property name for the password username.

--- a/src/main/java/com/enterprisepasswordsafe/engine/integration/PasswordChangerProperty.java
+++ b/src/main/java/com/enterprisepasswordsafe/engine/integration/PasswordChangerProperty.java
@@ -16,12 +16,10 @@
 
 package com.enterprisepasswordsafe.engine.integration;
 
-import com.enterprisepasswordsafe.proguard.ExternalInterface;
-
 /**
  * Object holding the details of a property relevant to the password changer.
  */
-public class PasswordChangerProperty implements ExternalInterface {
+public class PasswordChangerProperty {
 
 	/**
 	 * The internal name of the property.

--- a/src/main/java/com/enterprisepasswordsafe/engine/jaas/AuthenticationSourceConfigurationOption.java
+++ b/src/main/java/com/enterprisepasswordsafe/engine/jaas/AuthenticationSourceConfigurationOption.java
@@ -16,15 +16,13 @@
 
 package com.enterprisepasswordsafe.engine.jaas;
 
-import com.enterprisepasswordsafe.proguard.JavaBean;
-
 import java.util.Set;
 
 /**
  * Class representing a configuration object for an authentication source.
  */
 public class AuthenticationSourceConfigurationOption
-	implements Comparable<AuthenticationSourceConfigurationOption>, JavaBean {
+	implements Comparable<AuthenticationSourceConfigurationOption> {
 
 	/**
 	 * The types of configuration.

--- a/src/main/java/com/enterprisepasswordsafe/engine/jaas/AuthenticationSourceModule.java
+++ b/src/main/java/com/enterprisepasswordsafe/engine/jaas/AuthenticationSourceModule.java
@@ -16,26 +16,24 @@
 
 package com.enterprisepasswordsafe.engine.jaas;
 
-import com.enterprisepasswordsafe.proguard.ExternalInterface;
-
 import java.util.Set;
 
 /**
  * Authentication source module interface. Implemented by JAAS modules which
  * can be configured by the user.
  */
-public interface AuthenticationSourceModule extends ExternalInterface {
+public interface AuthenticationSourceModule {
 
 	/**
 	 * Return the configuration options for this module.
 	 * 
 	 * @return The Set of configuration options.
 	 */
-	public Set<AuthenticationSourceConfigurationOption> getConfigurationOptions();
+	Set<AuthenticationSourceConfigurationOption> getConfigurationOptions();
 	
 	/**
 	 * Get the notes to display on the configuration page.
 	 */
-	
-	public String getConfigurationNotes();
+
+	String getConfigurationNotes();
 }

--- a/src/main/java/com/enterprisepasswordsafe/engine/jaas/EPSJAASConfiguration.java
+++ b/src/main/java/com/enterprisepasswordsafe/engine/jaas/EPSJAASConfiguration.java
@@ -16,15 +16,12 @@
 
 package com.enterprisepasswordsafe.engine.jaas;
 
-import com.enterprisepasswordsafe.proguard.ExternalInterface;
-
+import javax.security.auth.login.AppConfigurationEntry;
+import javax.security.auth.login.Configuration;
 import java.util.HashMap;
 import java.util.Map;
 
-import javax.security.auth.login.AppConfigurationEntry;
-import javax.security.auth.login.Configuration;
-
-public final class EPSJAASConfiguration extends Configuration implements ExternalInterface {
+public final class EPSJAASConfiguration extends Configuration {
 
     public static final String DATABASE_APPLICATION_CONFIGURATION = "Database";
 

--- a/src/main/java/com/enterprisepasswordsafe/engine/nodes/GroupNodeDefaultPermission.java
+++ b/src/main/java/com/enterprisepasswordsafe/engine/nodes/GroupNodeDefaultPermission.java
@@ -1,15 +1,12 @@
 package com.enterprisepasswordsafe.engine.nodes;
 
-
 import com.enterprisepasswordsafe.engine.database.Group;
-import com.enterprisepasswordsafe.proguard.JavaBean;
 
 /**
  * Class holding the details of the default permissions a group has for a node
  */
 
-public class GroupNodeDefaultPermission
-        implements JavaBean {
+public class GroupNodeDefaultPermission {
     private final Group group;
     private final String permission;
 

--- a/src/main/java/com/enterprisepasswordsafe/engine/nodes/UserNodeDefaultPermission.java
+++ b/src/main/java/com/enterprisepasswordsafe/engine/nodes/UserNodeDefaultPermission.java
@@ -1,14 +1,12 @@
 package com.enterprisepasswordsafe.engine.nodes;
 
 import com.enterprisepasswordsafe.engine.database.derived.UserSummary;
-import com.enterprisepasswordsafe.proguard.JavaBean;
 
 /**
  * Class holding the details of the default permissions a user has for a node
  */
 
-public class UserNodeDefaultPermission
-        implements JavaBean {
+public class UserNodeDefaultPermission {
     private final UserSummary user;
     private final String permission;
 

--- a/src/main/java/com/enterprisepasswordsafe/engine/reports/AccessReport.java
+++ b/src/main/java/com/enterprisepasswordsafe/engine/reports/AccessReport.java
@@ -18,7 +18,6 @@ package com.enterprisepasswordsafe.engine.reports;
 
 import com.enterprisepasswordsafe.engine.accesscontrol.AccessControl;
 import com.enterprisepasswordsafe.engine.database.*;
-import com.enterprisepasswordsafe.proguard.ExternalInterface;
 
 import java.io.IOException;
 import java.io.PrintWriter;
@@ -27,8 +26,7 @@ import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 
-public class AccessReport
-    implements ExternalInterface {
+public class AccessReport {
 
     private static final String GET_ACCESSIBLE_PASSWORDS_FOR_USER_SQL =
             "SELECT item_id FROM user_access_control WHERE user_id = ?";

--- a/src/main/java/com/enterprisepasswordsafe/engine/utils/InvalidLicenceException.java
+++ b/src/main/java/com/enterprisepasswordsafe/engine/utils/InvalidLicenceException.java
@@ -16,8 +16,6 @@
 
 package com.enterprisepasswordsafe.engine.utils;
 
-import com.enterprisepasswordsafe.proguard.ExternalInterface;
-
 import java.security.GeneralSecurityException;
 
 /**
@@ -25,8 +23,7 @@ import java.security.GeneralSecurityException;
  */
 
 public class InvalidLicenceException
-        extends GeneralSecurityException
-        implements ExternalInterface {
+        extends GeneralSecurityException {
 
     /**
 	 * 

--- a/src/main/java/com/enterprisepasswordsafe/engine/utils/PasswordGenerator.java
+++ b/src/main/java/com/enterprisepasswordsafe/engine/utils/PasswordGenerator.java
@@ -16,12 +16,10 @@
 
 package com.enterprisepasswordsafe.engine.utils;
 
-import com.enterprisepasswordsafe.proguard.ExternalInterface;
-
 /**
  * Interface for password generator classes which can be used during an import
  */
-public interface PasswordGenerator extends ExternalInterface {
+public interface PasswordGenerator {
 
     /**
      * Generate a random password. This is used when users are imported

--- a/src/main/java/com/enterprisepasswordsafe/ui/web/servlets/ViewRARequests.java
+++ b/src/main/java/com/enterprisepasswordsafe/ui/web/servlets/ViewRARequests.java
@@ -30,7 +30,6 @@ import com.enterprisepasswordsafe.engine.database.ApproverListDAO;
 import com.enterprisepasswordsafe.engine.database.RestrictedAccessRequest;
 import com.enterprisepasswordsafe.engine.database.RestrictedAccessRequestDAO;
 import com.enterprisepasswordsafe.engine.database.User;
-import com.enterprisepasswordsafe.proguard.JavaBean;
 import com.enterprisepasswordsafe.ui.web.utils.SecurityUtils;
 
 /**
@@ -84,7 +83,7 @@ public final class ViewRARequests extends HttpServlet {
      */
 
     public static class RASummary
-    	implements Comparable<RASummary>, JavaBean {
+    	implements Comparable<RASummary> {
 
     	/**
     	 * The ID of the summary.


### PR DESCRIPTION
Proguard usage was introduced when this was a commercial product and we wanted obfuscation, but now it's open source having the stack traces easily understandable is more useful.