### PR TITLE
Use BIGINT instead of LONG for MySQL

### DIFF
--- a/src/main/java/com/enterprisepasswordsafe/database/vendorspecific/implementations/MysqlDAL.java
+++ b/src/main/java/com/enterprisepasswordsafe/database/vendorspecific/implementations/MysqlDAL.java
@@ -34,7 +34,7 @@ public class MysqlDAL
 	{
 		super();
 
-		translationMap.put( ColumnSpecification.TYPE_LONG, "LONG" );
+		translationMap.put( ColumnSpecification.TYPE_LONG, "BIGINT" );
 		translationMap.put( ColumnSpecification.TYPE_INT, "INT" );
 		translationMap.put( ColumnSpecification.TYPE_CHAR, "CHAR" );
 		translationMap.put( ColumnSpecification.TYPE_ID, "VARCHAR(20)" );


### PR DESCRIPTION
LONG isn't listed on the MySQL supported data-types (https://dev.mysql.com/doc/refman/8.0/en/integer-types.html) so we should replace it with the supported BIGINT.