### PR TITLE
Fix user editing

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,6 @@
 import net.ltgt.gradle.errorprone.errorprone
 import org.gradle.api.tasks.testing.logging.TestLogEvent
+import org.gradle.api.tasks.testing.logging.TestExceptionFormat
 
 buildscript {
     repositories {
@@ -60,6 +61,7 @@ tasks.withType<Test> {
 
     testLogging {
         events = mutableSetOf(TestLogEvent.FAILED, TestLogEvent.PASSED, TestLogEvent.SKIPPED)
+        exceptionFormat = TestExceptionFormat.FULL
     }
 }
 

--- a/src/main/java/com/enterprisepasswordsafe/database/GroupDAO.java
+++ b/src/main/java/com/enterprisepasswordsafe/database/GroupDAO.java
@@ -70,6 +70,14 @@ public class GroupDAO extends GroupStoreManipulator
             + " ORDER BY grp.group_name ASC";
 
     /**
+     * The SQL statement to get all the available groups.
+     */
+
+    private static final String GET_ALL_NON_SYSTEM_GROUPS_SQL = "SELECT " + GROUP_FIELDS + " FROM groups grp "
+            + " WHERE " + EXCLUDE_RESERVED_GROUP_CLAUSE+" AND grp.status < " + Group.STATUS_DELETED
+            + " ORDER BY grp.group_name ASC";
+
+    /**
      * The SQL statement to get all the available enabled groups.
      */
 
@@ -209,6 +217,10 @@ public class GroupDAO extends GroupStoreManipulator
     public List<Group> getAll()
     	throws SQLException {
     	return getMultiple(GET_ALL_GROUPS_SQL);
+    }
+
+    public List<Group> getNonSystem() throws SQLException {
+	    return getMultiple(GET_ALL_NON_SYSTEM_GROUPS_SQL);
     }
 
     public List<Group> getAllEnabled()

--- a/src/main/java/com/enterprisepasswordsafe/engine/users/UserClassifier.java
+++ b/src/main/java/com/enterprisepasswordsafe/engine/users/UserClassifier.java
@@ -5,6 +5,7 @@ import com.enterprisepasswordsafe.database.MembershipDAO;
 import com.enterprisepasswordsafe.database.User;
 
 import java.sql.SQLException;
+import java.util.Map;
 
 /**
  * Class to identify which type of user this is. This class must be thread-safe.
@@ -15,7 +16,11 @@ public class UserClassifier {
     private final MembershipDAO membershipDAO;
 
     public UserClassifier() {
-        membershipDAO = MembershipDAO.getInstance();
+        this(MembershipDAO.getInstance());
+    }
+
+    UserClassifier(MembershipDAO membershipDAO) {
+        this.membershipDAO = membershipDAO;
     }
 
     public boolean isMasterAdmin(User user) {
@@ -41,5 +46,25 @@ public class UserClassifier {
             throws SQLException {
         return (!user.getId().equals(ADMIN_USER_ID))
                 && membershipDAO.isMemberOf(user.getId(), Group.NON_VIEWING_GROUP_ID);
+    }
+
+    public UserLevel getUserLevelFor(User user) throws SQLException {
+        if(isAdministrator(user)) {
+            return UserLevel.ADMINISTRATOR;
+        }
+        if(isSubadministrator(user)) {
+            return UserLevel.PRIVILEGED;
+        }
+        return UserLevel.REGULAR;
+    }
+
+    public UserLevel getUserLevelFrom(Map<String, Object> userMemberships) {
+        if(userMemberships.containsKey(Group.ADMIN_GROUP_ID)) {
+            return UserLevel.ADMINISTRATOR;
+        }
+        if(userMemberships.containsKey(Group.SUBADMIN_GROUP_ID)) {
+            return UserLevel.PRIVILEGED;
+        }
+        return UserLevel.REGULAR;
     }
 }

--- a/src/main/java/com/enterprisepasswordsafe/engine/users/UserLevel.java
+++ b/src/main/java/com/enterprisepasswordsafe/engine/users/UserLevel.java
@@ -1,0 +1,5 @@
+package com.enterprisepasswordsafe.engine.users;
+
+public enum UserLevel {
+    ADMINISTRATOR, PRIVILEGED, REGULAR
+}

--- a/src/main/webapp/admin/edit_user.jsp
+++ b/src/main/webapp/admin/edit_user.jsp
@@ -68,10 +68,10 @@ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
         <div class="form-group">
             <label for="user_type">User Type</label>
             <c:choose>
-                <c:when test="${requestScope.user.administrator}">
+                <c:when test="${requestScope.user_level eq 'ADMINISTRATOR'}">
                     <c:set var="ut_epsadmin_selected" value="selected=\"selected\"" />
                 </c:when>
-                <c:when test="${requestScope.user.subadministrator}">
+                <c:when test="${requestScope.user_level eq 'PRIVILEGED'}">
                     <c:set var="ut_epssubadmin_selected" value="selected=\"selected\"" />
                 </c:when>
                 <c:otherwise>
@@ -120,7 +120,7 @@ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
         <jsp:include page="/WEB-INF/includes/yes_no_select.jsp">
             <jsp:param name="input_label" value="User can't view passwords" />
             <jsp:param name="input_name" value="noview" />
-            <jsp:param name="input_value" value="${requestScope.user.nonViewingUser}" />
+            <jsp:param name="input_value" value="${requestScope.non_viewing}" />
         </jsp:include>
 
         <c:if test="${not empty requestScope.groups}">

--- a/src/test/java/com/enterprisepasswordsafe/engine/users/UserClassifierTests.java
+++ b/src/test/java/com/enterprisepasswordsafe/engine/users/UserClassifierTests.java
@@ -1,0 +1,124 @@
+package com.enterprisepasswordsafe.engine.users;
+
+import com.enterprisepasswordsafe.database.Group;
+import com.enterprisepasswordsafe.database.MembershipDAO;
+import com.enterprisepasswordsafe.database.User;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.sql.SQLException;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+public class UserClassifierTests {
+
+    private static final String TEST_USER_ID = "u1234test";
+
+    @Mock
+    MembershipDAO mockMembershipDAO;
+    @Mock
+    User mockUser;
+
+    private UserClassifier instanceUnderTest;
+
+    @BeforeEach
+    public void setUp() {
+        instanceUnderTest = new UserClassifier(mockMembershipDAO);
+    }
+
+    @Test
+    public void testAdminUserIsDetectedFromStorage() throws SQLException {
+        setUserIdOnMock();
+        setUserAsAdmin();
+
+        UserLevel level = instanceUnderTest.getUserLevelFor(mockUser);
+
+        assertEquals(UserLevel.ADMINISTRATOR, level);
+        assertTrue(instanceUnderTest.isAdministrator(mockUser));
+        assertFalse(instanceUnderTest.isSubadministrator(mockUser));
+        assertTrue(instanceUnderTest.isPriviledgedUser(mockUser));
+    }
+
+    @Test
+    public void testAdminUserIsDetectedFromMap() {
+        UserLevel level = instanceUnderTest.getUserLevelFrom(Map.of(Group.ADMIN_GROUP_ID, new Object()));
+
+        assertEquals(UserLevel.ADMINISTRATOR, level);
+    }
+
+    @Test
+    public void testPrivilegedUserIsDetectedFromStorage() throws SQLException {
+        setUserIdOnMock();
+        setUserAsPrivileged();
+
+        UserLevel level = instanceUnderTest.getUserLevelFor(mockUser);
+
+        assertEquals(UserLevel.PRIVILEGED, level);
+        assertFalse(instanceUnderTest.isAdministrator(mockUser));
+        assertTrue(instanceUnderTest.isSubadministrator(mockUser));
+        assertTrue(instanceUnderTest.isPriviledgedUser(mockUser));
+    }
+
+    @Test
+    public void testPrivilegedUserIsDetectedFromMap() {
+        UserLevel level = instanceUnderTest.getUserLevelFrom(Map.of(Group.SUBADMIN_GROUP_ID, new Object()));
+
+        assertEquals(UserLevel.PRIVILEGED, level);
+    }
+
+    @Test
+    public void testRegularUserIsDetectedFromStorage() throws SQLException {
+        UserLevel level = instanceUnderTest.getUserLevelFor(mockUser);
+
+        assertEquals(UserLevel.REGULAR, level);
+        assertFalse(instanceUnderTest.isAdministrator(mockUser));
+        assertFalse(instanceUnderTest.isSubadministrator(mockUser));
+        assertFalse(instanceUnderTest.isPriviledgedUser(mockUser));
+    }
+    @Test
+    public void testRegularUserIsDetectedFromMap() {
+        UserLevel level = instanceUnderTest.getUserLevelFrom(Map.of());
+
+        assertEquals(UserLevel.REGULAR, level);
+    }
+
+    @Test
+    public void testNonViewingUserIsDetectedFromStorage() throws SQLException {
+        setUserIdOnMock();
+        setUserAsNonViewing();
+
+        assertTrue(instanceUnderTest.isNonViewingUser(mockUser));
+    }
+
+    @Test
+    public void testViewingUserIsDetectedFromStorage() throws SQLException {
+        when(mockUser.getId()).thenReturn(TEST_USER_ID);
+
+        assertFalse(instanceUnderTest.isNonViewingUser(mockUser));
+    }
+
+    private void setUserAsAdmin() throws SQLException {
+        when(mockMembershipDAO.isMemberOf(TEST_USER_ID, Group.ADMIN_GROUP_ID)).thenReturn(true);
+    }
+
+    private void setUserAsPrivileged() throws SQLException {
+        when(mockMembershipDAO.isMemberOf(TEST_USER_ID, Group.ADMIN_GROUP_ID)).thenReturn(false);
+        when(mockMembershipDAO.isMemberOf(TEST_USER_ID, Group.SUBADMIN_GROUP_ID)).thenReturn(true);
+    }
+
+    private void setUserAsNonViewing() throws SQLException {
+        when(mockMembershipDAO.isMemberOf(TEST_USER_ID, Group.NON_VIEWING_GROUP_ID)).thenReturn(true);
+    }
+
+    private void setUserIdOnMock() {
+        when(mockUser.getId()).thenReturn(TEST_USER_ID);
+    }
+}


### PR DESCRIPTION
An exception in the user editing page has been reported in issue #38 which was due to the user type being moved out of the user object. This commit switches that JSP page to use the user classifier for determining the user type.